### PR TITLE
Change order of code generation in hooks

### DIFF
--- a/SpecFlow.TestProjectGenerator/Factories/BindingsGenerator/CSharpBindingsGenerator.cs
+++ b/SpecFlow.TestProjectGenerator/Factories/BindingsGenerator/CSharpBindingsGenerator.cs
@@ -188,8 +188,8 @@ public class {$"HooksClass_{Guid.NewGuid():N}"}
     {scopeMethodAttributes}
     public {staticKeyword} void {name}()
     {{
-        global::Log.LogHook(); 
         {code}
+        global::Log.LogHook(); 
     }}   
 }}
 ";

--- a/SpecFlow.TestProjectGenerator/Factories/BindingsGenerator/FSharpBindingsGenerator.cs
+++ b/SpecFlow.TestProjectGenerator/Factories/BindingsGenerator/FSharpBindingsGenerator.cs
@@ -71,8 +71,8 @@ type internal Log =
 
             return $@"
 [<{attributeName}(@""{regex}"")>] let {methodName}({parameter}) : unit =
-    LocalApp.Log.LogStep @""{methodName}""
     {methodImplementation}
+    LocalApp.Log.LogStep @""{methodName}""
 ";
         }
 

--- a/SpecFlow.TestProjectGenerator/Factories/BindingsGenerator/VbBindingsGenerator.cs
+++ b/SpecFlow.TestProjectGenerator/Factories/BindingsGenerator/VbBindingsGenerator.cs
@@ -151,8 +151,8 @@ Public Class {Guid.NewGuid()}
     <[{hookType}({hookTypeAttributeTagsString})]>_
     {methodScopeAttributes}
     Public {staticKeyword} Sub {name}()
-        Console.WriteLine(""-> hook: {name}"")
         {code}
+        Console.WriteLine(""-> hook: {name}"")
     End Sub
 End Class
 ";


### PR DESCRIPTION
Execute `code`, and only then write message to output.