### PR TITLE
Use proper way to detect msbuild.exe in vs2017/vs2019

### DIFF
--- a/SpecFlow.TestProjectGenerator/TechTalk.SpecFlow.TestProjectGenerator.csproj
+++ b/SpecFlow.TestProjectGenerator/TechTalk.SpecFlow.TestProjectGenerator.csproj
@@ -14,7 +14,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NuGet.CommandLine" Version="4.5.1" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="vswhere" Version="2.3.2" />
+    <PackageReference Include="vswhere" Version="2.6.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net471'">

--- a/SpecFlow.TestProjectGenerator/VisualStudioFinder.cs
+++ b/SpecFlow.TestProjectGenerator/VisualStudioFinder.cs
@@ -7,7 +7,8 @@ namespace TechTalk.SpecFlow.TestProjectGenerator
 {
     public class VisualStudioFinder
     {
-        private const string VsWhereParameter = @"-latest -products * -requires Microsoft.VisualStudio.PackageGroup.TestTools.Core -property installationPath";
+        private const string VsWhereInstallationPathParameter = @"-latest -products * -requires Microsoft.VisualStudio.PackageGroup.TestTools.Core -property installationPath";
+        private const string VsWhereMsBuildParameter = @"-latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe";
         private readonly Folders _folders;
         private readonly IOutputWriter _outputWriter;
 
@@ -19,7 +20,17 @@ namespace TechTalk.SpecFlow.TestProjectGenerator
 
         public string Find()
         {
-            string vsWherePath = Path.Combine(_folders.GlobalPackages, "vswhere", "2.3.2", "tools", "vswhere.exe");
+            return ExecuteVsWhere(VsWhereInstallationPathParameter);
+        }
+
+        public string FindMSBuild()
+        {
+            return ExecuteVsWhere(VsWhereMsBuildParameter);
+        }
+
+        private string ExecuteVsWhere(string vsWhereParameters)
+        {
+            string vsWherePath = Path.Combine(_folders.GlobalPackages, "vswhere", "2.6.7", "tools", "vswhere.exe");
 
             if (!File.Exists(vsWherePath))
             {
@@ -27,22 +38,10 @@ namespace TechTalk.SpecFlow.TestProjectGenerator
             }
 
             var ph = new ProcessHelper();
-            var processResult = ph.RunProcess(_outputWriter, ".", vsWherePath, VsWhereParameter);
-
+            var processResult = ph.RunProcess(_outputWriter, ".", vsWherePath, vsWhereParameters);
 
             var lines = processResult.CombinedOutput.Split(new string[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries);
             return lines.First();
-        }
-
-        public string FindMSBuild()
-        {
-            var msbuildExe = Path.Combine(Find(), "MSBuild", "Current", "Bin", "msbuild.exe");
-            return msbuildExe;
-        }
-
-        public string FindDevEnv()
-        {
-            return Path.Combine(Find(), "Common7", "IDE", "devenv.exe");
         }
     }
 }


### PR DESCRIPTION
Msbuild was detected with vswhere nuget package as lastest installation path + /Current/Bin/MsBuild.exe

/Current works only for VS2019, in VS2017 it is still /15.0, so if developer has only VS2017, path will not work. 

In this PR approach from https://github.com/Microsoft/vswhere/wiki/Find-MSBuild is used, last vswhere version allows detection of msbuild directly. 

PR is tested with using VsWhereMsBuildParameter = @"-version [15.0,16.0) ...." instead of "-lastest ...."  to imitate having only VS2017 installed.