### PR TITLE
Add method to check if Compile Output has contains string

### DIFF
--- a/SpecFlow.TestProjectGenerator/Driver/SolutionDriver.cs
+++ b/SpecFlow.TestProjectGenerator/Driver/SolutionDriver.cs
@@ -123,11 +123,15 @@ namespace TechTalk.SpecFlow.TestProjectGenerator.Driver
             _compileResult.IsSuccessful.Should().BeTrue("the project should have compiled successfully.\r\n\r\n------ Build output ------\r\n{0}", _compileResult.Output);
         }
 
-
         public void CheckSolutionShouldHaseCompileError()
         {
             _compileResult.Should().NotBeNull("the project should have compiled");
             _compileResult.IsSuccessful.Should().BeFalse("There should be a compile error");
+        }
+
+        public bool CheckCompileOutputForString(string str)
+        {
+            return _compileResult.Output.Contains(str);
         }
     }
 


### PR DESCRIPTION
For configuration tests in the TechTalk.Sepcflow.Spec project, it is checking if the test result output contains strings such as "using specflow.json". This output currently seems to appear in the compile output instead of the test results, thus I have added this method and will fix the tests in the main repository if this gets merged. Please let me know if this is not the expected behavior!

Thanks,

Billy Choi