### PR TITLE
lower the verbosity level of dotnet test

### DIFF
--- a/SpecFlow.TestProjectGenerator/VSTestExecutionDriver.cs
+++ b/SpecFlow.TestProjectGenerator/VSTestExecutionDriver.cs
@@ -141,7 +141,7 @@ namespace TechTalk.SpecFlow.TestProjectGenerator
             var argumentsBuilder = new StringBuilder();
 
             argumentsBuilder.Append(GenerateTrxLoggerParameter());
-            argumentsBuilder.Append($" {GenerateVerbosityParameter("d")}");
+            argumentsBuilder.Append($" {GenerateVerbosityParameter("m")}");
 
             string additionalPackagesFoldersParameters = GenerateAdditionalPackagesFoldersParameters();
             if (additionalPackagesFoldersParameters is string additionalPackagesFoldersParametersString)


### PR DESCRIPTION
 to reduce the size of the test execution output