### PR TITLE
fix RunSettings file path to absolute path

### DIFF
--- a/SpecFlow.TestProjectGenerator/VSTestExecutionDriver.cs
+++ b/SpecFlow.TestProjectGenerator/VSTestExecutionDriver.cs
@@ -156,7 +156,8 @@ namespace TechTalk.SpecFlow.TestProjectGenerator
 
             if (RunSettingsFile.IsNotNullOrWhiteSpace())
             {
-                argumentsBuilder.Append($" --settings \"{RunSettingsFile}\"");
+                var pathToRunSettingsFile = Path.Combine(_testProjectFolders.ProjectFolder, RunSettingsFile);
+                argumentsBuilder.Append($" --settings \"{pathToRunSettingsFile}\"");
             }
 
             //string pathToSpecFlowProject = Path.Combine(_testProjectFolders.ProjectFolder, $"{Path.GetFileName(_testProjectFolders.ProjectFolder)}.csproj");


### PR DESCRIPTION
The settings parameter of the dotnet test commmand has been changed between netcore 3.0 and 3.1. Previously the runsettings file was automatically found in the project folder.